### PR TITLE
fix(background): make currentImage available in storage

### DIFF
--- a/background.js
+++ b/background.js
@@ -350,6 +350,7 @@ async function fetchTrmnlImage(forceRefresh = false) {
     "nextFetch",
     "retryCount",
     "retryAfter",
+    "currentImage",
   ]);
 
   const apiKey = storage.selectedDevice?.api_key;


### PR DESCRIPTION
It is later used with `storage.currentImage` so we need to fetch it here.