### PR TITLE
Added configuration options for UI, Screen, and Dimming.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # TRMNL Chrome Extension
 
-A Chrome extension that displays images from TRMNL's API in your new tab page with automatic refresh functionality. **Note**: requires a TRMNL account with a physical device or [BYOD](https://shop.usetrmnl.com/products/byod) license.
+A Chrome extension that displays images from TRMNL's API in your new tab page with automatic refresh functionality. **Note**: requires a TRMNL account with a physical device or [BYOD](https://shop.trmnl.com/products/byod) license.
 
 ## Features
 

--- a/background.js
+++ b/background.js
@@ -12,7 +12,7 @@ chrome.storage.onChanged.addListener((changes, namespace) => {
 // Constants
 const HOSTS = {
   development: "http://localhost:3000",
-  production: "https://usetrmnl.com",
+  production: "https://trmnl.com",
 };
 
 const getBaseUrl = async () => {

--- a/manifest.json
+++ b/manifest.json
@@ -4,14 +4,14 @@
   "version": "1.1",
   "description": "Displays images from TRMNL API on new tab pages",
   "permissions": ["storage", "alarms"],
-  "host_permissions": ["http://localhost:3000/*", "https://usetrmnl.com/*"],
+  "host_permissions": ["http://localhost:3000/*", "https://trmnl.com/*"],
   "devtools_page": "devtools.html",
   "chrome_url_overrides": {
     "newtab": "newtab.html"
   },
   "content_scripts": [
     {
-      "matches": ["https://usetrmnl.com/*", "http://localhost:3000/*"],
+      "matches": ["https://trmnl.com/*", "http://localhost:3000/*"],
       "js": ["dashboard-content.js"]
     }
   ],

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "TRMNL New Tab Display",
-  "version": "1.1",
+  "version": "1.2",
   "description": "Displays images from TRMNL API on new tab pages",
   "permissions": ["storage", "alarms"],
   "host_permissions": ["http://localhost:3000/*", "https://trmnl.com/*"],

--- a/newtab.html
+++ b/newtab.html
@@ -16,44 +16,44 @@
         <link
             rel="apple-touch-icon"
             type="image/png"
-            href="https://usetrmnl.com/images/favicons/apple-touch-icon-76x76.png"
+            href="https://trmnl.com/images/favicons/apple-touch-icon-76x76.png"
             sizes="76x76"
         />
         <link
             rel="apple-touch-icon"
             type="image/png"
-            href="https://usetrmnl.com/images/favicons/apple-touch-icon-120x120.png"
+            href="https://trmnl.com/images/favicons/apple-touch-icon-120x120.png"
             sizes="120x120"
         />
         <link
             rel="apple-touch-icon"
             type="image/png"
-            href="https://usetrmnl.com/images/favicons/apple-touch-icon-152x152.png"
+            href="https://trmnl.com/images/favicons/apple-touch-icon-152x152.png"
             sizes="152x152"
         />
         <link
             rel="apple-touch-icon"
             type="image/png"
-            href="https://usetrmnl.com/images/favicons/apple-touch-icon-167x167.png"
+            href="https://trmnl.com/images/favicons/apple-touch-icon-167x167.png"
             sizes="167x167"
         />
         <link
             rel="apple-touch-icon"
             type="image/png"
-            href="https://usetrmnl.com/images/favicons/apple-touch-icon-180x180.png"
+            href="https://trmnl.com/images/favicons/apple-touch-icon-180x180.png"
             sizes="180x180"
         />
 
         <link
             rel="icon"
             type="image/png"
-            href="https://usetrmnl.com/images/favicons/favicon-16x16.png"
+            href="https://trmnl.com/images/favicons/favicon-16x16.png"
             sizes="16x16"
         />
         <link
             rel="icon"
             type="image/png"
-            href="https://usetrmnl.com/images/favicons/favicon-32x32.png"
+            href="https://trmnl.com/images/favicons/favicon-32x32.png"
             sizes="32x32"
         />
     </head>

--- a/newtab.html
+++ b/newtab.html
@@ -11,6 +11,7 @@
             href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400..800;1,400..800&family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap"
             rel="stylesheet"
         />
+        <link rel="stylesheet" href="variables.css" />
         <link rel="stylesheet" href="styles.css" />
         <link
             rel="apple-touch-icon"
@@ -57,7 +58,7 @@
         />
     </head>
     <body
-        class="flex justify-center bg-trmnl dark:bg-gray-850 max-w-full overflow-x-hidden"
+        class="flex justify-center bg-trmnl dark:bg-gray-850 max-w-full overflow-x-hidden css-transitions-only-after-page-load"
     >
         <div id="container">
             <div

--- a/newtab.js
+++ b/newtab.js
@@ -100,20 +100,15 @@ async function initStyles() {
   document.body.classList.add("css-transitions-only-after-page-load")
   setTimeout(() => document.body.classList.remove("css-transitions-only-after-page-load"), 32);
 
+  const removeClassByPrefix = (prefix) => document.body.classList.remove(...Array.from(document.body.classList).filter(cls => cls.startsWith(prefix)));
+
   const updateStyles = async () => {
-    const remove = (prefix) => {
-      document.body.classList.remove(
-        ...Array.from(document.body.classList).filter((cls) =>
-          cls.startsWith(prefix),
-        ),
-      );
-    }
 
     const { displayStyles } = await chrome.storage.local.get("displayStyles");
-    
-    remove("style-ui--");
-    remove("style-screen--");
-    remove("style-dimming--");
+
+    removeClassByPrefix("style-ui--");
+    removeClassByPrefix("style-screen--");
+    removeClassByPrefix("style-dimming--");
 
     if(displayStyles) {
       const { uiStyle, screenStyle, dimmingStyle } = displayStyles;

--- a/newtab.js
+++ b/newtab.js
@@ -27,7 +27,7 @@ async function initNewTab() {
     const baseUrl =
       environment === "development"
         ? "http://localhost:3000"
-        : "https://usetrmnl.com";
+        : "https://trmnl.com";
 
     // Try to get devices from local storage first
     const { devices: storedDevices } =
@@ -91,7 +91,7 @@ async function initNewTab() {
     const baseUrl =
       environment === "development"
         ? "http://localhost:3000"
-        : "https://usetrmnl.com";
+        : "https://trmnl.com";
     window.location.href = `${baseUrl}/login`;
   }
 }

--- a/newtab.js
+++ b/newtab.js
@@ -20,6 +20,8 @@ let countdownIntervalId = null;
 // Initialize the new tab page
 async function initNewTab() {
   try {
+    await initStyles();
+
     // First try to get the environment setting
     const { environment } = await chrome.storage.local.get("environment");
     const baseUrl =
@@ -92,6 +94,42 @@ async function initNewTab() {
         : "https://usetrmnl.com";
     window.location.href = `${baseUrl}/login`;
   }
+}
+
+async function initStyles() {
+  document.body.classList.add("css-transitions-only-after-page-load")
+  setTimeout(() => document.body.classList.remove("css-transitions-only-after-page-load"), 32);
+
+  const updateStyles = async () => {
+    const remove = (prefix) => {
+      document.body.classList.remove(
+        ...Array.from(document.body.classList).filter((cls) =>
+          cls.startsWith(prefix),
+        ),
+      );
+    }
+
+    const { displayStyles } = await chrome.storage.local.get("displayStyles");
+    
+    remove("style-ui--");
+    remove("style-screen--");
+    remove("style-dimming--");
+
+    if(displayStyles) {
+      const { uiStyle, screenStyle, dimmingStyle } = displayStyles;
+
+      document.body.classList.add(`style-ui--${uiStyle || "auto"}`);
+      document.body.classList.add(`style-screen--${screenStyle || "auto-system"}`);
+      document.body.classList.add(`style-dimming--${dimmingStyle || "until-hover"}`);
+    }
+  }
+
+  chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+    if(message.action === "reloadStyles")
+      updateStyles();
+  })
+
+  await updateStyles();
 }
 
 // Set up event listeners

--- a/panel.js
+++ b/panel.js
@@ -23,7 +23,7 @@ async function setDevelopmentEnvironment() {
 async function setProductionEnvironment() {
   try {
     await chrome.storage.local.set({ environment: "production" });
-    console.log("Set to production environment (usetrmnl.com)");
+    console.log("Set to production environment (trmnl.com)");
     await updateEnvironmentDisplay();
   } catch (error) {
     console.error("Error setting production:", error);

--- a/popup.html
+++ b/popup.html
@@ -148,6 +148,48 @@
                 </select>
             </div>
 
+            <div class="form-group">
+                <label for="ui-style-select" class="inter-600 mb-1 block"
+                    >User Interface Style</label
+                >
+                <select
+                    id="ui-style-select"
+                    class="w-full p-2 rounded-lg bg-gray-100 dark:bg-gray-700 border border-gray-300 dark:border-gray-650 text-gray-900 dark:text-white focus:ring-2 focus:ring-primary-500 dark:focus:ring-primary-600"
+                >
+                    <option value="auto">Auto (as system)</option>
+                    <option value="light">Light</option>
+                    <option value="dark">Dark</option>
+                </select>
+            </div>
+
+            <div class="form-group">
+                <label for="screen-style-select" class="inter-600 mb-1 block"
+                    >Screen Style</label
+                >
+                <select
+                    id="screen-style-select"
+                    class="w-full p-2 rounded-lg bg-gray-100 dark:bg-gray-700 border border-gray-300 dark:border-gray-650 text-gray-900 dark:text-white focus:ring-2 focus:ring-primary-500 dark:focus:ring-primary-600"
+                >
+                    <option value="auto-system">Auto (as system)</option>
+                    <option value="light">Light</option>
+                    <option value="dark">Dark</option>
+                </select>
+            </div>
+
+            <div class="form-group">
+                <label for="dimming-style-select" class="inter-600 mb-1 block"
+                    >Dimming Style</label
+                >
+                <select
+                    id="dimming-style-select"
+                    class="w-full p-2 rounded-lg bg-gray-100 dark:bg-gray-700 border border-gray-300 dark:border-gray-650 text-gray-900 dark:text-white focus:ring-2 focus:ring-primary-500 dark:focus:ring-primary-600"
+                >
+                    <option value="until-hover">Dim until Hover</option>
+                    <option value="yes">Dim</option>
+                    <option value="no">No Dimming</option>
+                </select>
+            </div>
+
             <div class="status" id="status"></div>
 
             <div class="info" style="display: none">

--- a/popup.js
+++ b/popup.js
@@ -25,6 +25,7 @@ async function initPopup() {
   setupEventListeners();
   await loadSettings();
   await loadDevices();
+  await loadStyles();
   updateStatusInfo();
 }
 
@@ -202,6 +203,33 @@ async function loadDevices() {
   });
 }
 
+// Load display styles from storage
+async function loadStyles() {
+  const setStyle = async (key, value) => {
+    const storage = await chrome.storage.local.get(["displayStyles"]);
+    const styles = storage.displayStyles || {};
+    styles[key] = value;
+    await chrome.storage.local.set({ displayStyles: styles });
+    await chrome.runtime.sendMessage({ action: "reloadStyles" });
+
+    showStatus("Settings saved");
+  }
+
+  const { displayStyles } = await chrome.storage.local.get("displayStyles");
+
+  const uiSelect = document.getElementById("ui-style-select");
+  uiSelect.addEventListener("change", async (e) => setStyle("uiStyle", e.target.value));
+  uiSelect.value = displayStyles?.uiStyle || "auto";
+  
+  const screenSelect = document.getElementById("screen-style-select");
+  screenSelect.addEventListener("change", async (e) => setStyle("screenStyle", e.target.value));
+  screenSelect.value = displayStyles?.screenStyle || "auto-system";
+
+  const dimmingSelect = document.getElementById("dimming-style-select");
+  dimmingSelect.addEventListener("change", async (e) => setStyle("dimmingStyle", e.target.value));
+  dimmingSelect.value = displayStyles?.dimmingStyle || "until-hover";
+}
+
 // Set up event listeners
 function setupEventListeners() {
   // Save button
@@ -245,7 +273,6 @@ async function saveSettings() {
     });
 
     showStatus("Settings saved");
-    setTimeout(hideStatus, 3000);
   } else {
     showStatus("API key cannot be empty", true);
   }
@@ -264,7 +291,6 @@ function refreshImage() {
 
     setTimeout(() => {
       updateStatusInfo();
-      hideStatus();
     }, 3000);
   });
 }
@@ -310,11 +336,19 @@ async function updateStatusInfo() {
 }
 
 // Show a status message
+let statusTimeoutId;
 function showStatus(message, isError = false) {
   if (statusElement) {
     statusElement.textContent = message;
     statusElement.style.color = isError ? "#ff5555" : "#55ff55";
   }
+
+  if (statusTimeoutId) {
+    clearTimeout(statusTimeoutId);
+  }
+
+  if(!isError)
+    statusTimeoutId = setTimeout(hideStatus, 3000);
 }
 
 // Hide the status message

--- a/popup.js
+++ b/popup.js
@@ -46,7 +46,7 @@ async function loadDevices() {
     const apiUrl =
       environment === "development"
         ? "http://localhost:3000/devices.json"
-        : "https://usetrmnl.com/devices.json";
+        : "https://trmnl.com/devices.json";
 
     try {
       const response = await fetch(apiUrl);

--- a/styles.css
+++ b/styles.css
@@ -26,25 +26,17 @@ html {
     position: relative;
 }
 
+.css-transitions-only-after-page-load * {
+   transition: none !important;
+}
+
 #image-container img {
-    filter: sepia(20%) contrast(0.9);
-    transition: filter 0.2s ease-in-out;
+    filter: var(--screen-filter, none);
+    transition: var(--screen-transition, none);
 }
 
 #image-container img:hover {
-    filter: sepia(10%) contrast(1);
-}
-
-@media (prefers-color-scheme: dark) {
-    #image-container img {
-        filter: invert() brightness(0.65) sepia(45%) contrast(0.75);
-        box-shadow: none !important;
-    }
-
-    #image-container img:hover {
-        filter: invert() brightness(0.9) sepia(55%) contrast(0.75);
-        box-shadow: none !important;
-    }
+    filter: var(--screen-hover-filter, none);
 }
 
 #trmnl-image {
@@ -162,22 +154,22 @@ html {
     font-style: normal;
 }
 
-@media (prefers-color-scheme: dark) {
-    .dark\:bg-gray-850 {
-        background-color: rgb(15 15 15);
-    }
-}
-
 .w-\[802px\] {
     width: 802px;
 }
 
 .bg-trmnl {
-    background-color: #f0f0f0;
+    background-color: var(--ui-bg-color);
 }
 
-@media (prefers-color-scheme: dark) {
-    .bg-trmnl {
-        background-color: rgb(15 15 15);
-    }
+.dark\:bg-gray-850 {
+    background-color: var(--ui-bg-color);
+}
+
+.bg-trmnl {
+    background-color: var(--ui-bg-color);
+}
+
+.dark\:shadow-black {
+    --tw-shadow-color: var(--ui-shadow-color);
 }

--- a/variables.css
+++ b/variables.css
@@ -1,5 +1,5 @@
 /* User interface style variables */
-.style-ui--light {
+.style-ui--auto, .style-ui--light {
     --ui-bg-color: #f0f0f0;
     --ui-shadow-color: black;
 }
@@ -17,7 +17,7 @@
 }
 
 /* Screen style variables */
-.style-screen--light {
+.style-screen--auto-system, .style-screen--light {
     --screen-dim-filter:  sepia(20%) contrast(0.9);
     --screen-full-filter: sepia(10%) contrast(1);
 }

--- a/variables.css
+++ b/variables.css
@@ -1,0 +1,54 @@
+/* User interface style variables */
+.style-ui--light {
+    --ui-bg-color: #f0f0f0;
+    --ui-shadow-color: black;
+}
+
+.style-ui--dark {
+    --ui-bg-color: rgb(15 15 15);
+    --ui-shadow-color: #BBB; /* this is counter-intuitive but we invert() with a filter later */
+}
+
+@media (prefers-color-scheme: dark) {
+    .style-ui--auto {
+        --ui-bg-color: rgb(15 15 15);
+        --ui-shadow-color: #BBB; /* this is counter-intuitive but we invert() with a filter later */
+    }
+}
+
+/* Screen style variables */
+.style-screen--light {
+    --screen-dim-filter:  sepia(20%) contrast(0.9);
+    --screen-full-filter: sepia(10%) contrast(1);
+}
+
+.style-screen--dark {
+    --screen-dim-filter:  invert() brightness(0.65) sepia(45%) contrast(0.75);
+    --screen-full-filter: invert() brightness(0.9)  sepia(55%) contrast(0.75);
+}
+
+@media (prefers-color-scheme: dark) {
+    .style-screen--auto-system {
+        --screen-dim-filter:  invert() brightness(0.65) sepia(45%) contrast(0.75);
+        --screen-full-filter: invert() brightness(0.9)  sepia(55%) contrast(0.75);
+    }
+}
+
+/* Dimming style variables */
+.style-dimming--yes {
+    --screen-filter:       var(--screen-dim-filter);
+    --screen-hover-filter: var(--screen-dim-filter);
+    --screen-transition:   none;
+}
+
+.style-dimming--no {
+    --screen-filter:       var(--screen-full-filter);
+    --screen-hover-filter: var(--screen-full-filter);
+    --screen-transition:   none;
+}
+
+.style-dimming--until-hover {
+    --screen-filter:       var(--screen-dim-filter);
+    --screen-hover-filter: var(--screen-full-filter);
+    --screen-transition:   filter 0.2s ease-in-out;
+}


### PR DESCRIPTION
This pull request adds the below configuration options to the settings panel. These settings are persistence and hotreloaded upon change. Alongside this I applied a small fix to prevent the CSS transitions firing earlier than desired, and a change to the setStatus() function to manage its own cleanup timer.

Unfortunately I am unsure how to implement the `Auto (as TRMNL device)` option without further guidence, as this may change per rendered screen? I'm leaning towards omitting this option as if you put a screen in dark mode, we already receive it inverted as far as I know.

- [x] User Interface Style
  - [x] Light
  - [x] Dark
  - [x] Auto (as system)

- [x] Screen Style:
  - [x] Light
  - [x] Dark
  - [x] Auto (as system)
  - [ ] Auto (as trmnl device)

- [x] Dimming Style:
  - [x] Dim
  - [x] Dim until Hovered
  - [x] No dim

